### PR TITLE
Incluye comentario automático de revisores en PR.

### DIFF
--- a/.github/workflows/source-tests.yml
+++ b/.github/workflows/source-tests.yml
@@ -14,6 +14,7 @@ jobs:
       objetivo: ${{steps.pr_info.outputs.objetivo}}
       rama: ${{steps.pr_info.outputs.rama}}
       pr_milestone: ${{steps.pr_info.outputs.pr_milestone}}
+      pull_number: ${{steps.pr_info.outputs.pull_number}}
     steps:
       - id: pr_info
         name: Comprueba y analiza
@@ -194,7 +195,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: [ops-on-pr, ops-on-source, ops-using-API]
     env:
+      user: ${{ needs.ops-on-pr.outputs.user }}
+      repo: ${{ needs.ops-on-pr.outputs.repo }}
       objetivo: ${{ needs.ops-on-pr.outputs.objetivo }}
+      pull_number: ${{ needs.ops-on-pr.outputs.pull_number }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Fuentes de este repo (para JSON)
         uses: actions/checkout@v2

--- a/cpanfile
+++ b/cpanfile
@@ -7,3 +7,4 @@ requires "YAML";
 requires "Term::ANSIColor";
 requires "Net::Ping";
 requires "GitHub::Actions";
+requires "LWP::UserAgent";


### PR DESCRIPTION
- Requiere que JJ/grading-pr-info-gh-action exporte pull_number
- Requiere que secrets.GITHUB_TOKEN tenga habilitado como scope public_repo (autorización para comentar en pull requests de repositorios públicos)
- Falta generar el script t/random-reviewer mediante 'make revisores'
